### PR TITLE
Replacing handlebars for lodash template

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,32 @@ const messageBox = new MessageBox({
 ```
 
 Then when you change the language, any call to `messageBox.message()` that does not specify a language and is in a reactive context will rerun.
+
+### Template
+
+By default (and historically) the substitution of strings is made using `{{}}`, you can change this by passing the `interpolate` and` escape` options:
+
+```js
+const messageBox = new MessageBox({
+  messages: { ... },
+  interpolate: /{{{([^\{\}#][\s\S]+?)}}}/g, // default
+  escape: /{{([^\{\}#][\s\S]+?)}}/g; // default
+});
+```
+
+It is also possible (but I would not recommend) to use logic within messages by using the `evaluate` option:
+
+```js
+var SUGGESTED_EVALUATE = require('MessageBox').SUGGESTED_EVALUATE
+// or
+import { SUGGESTED_EVALUATE } from 'MessageBox';
+
+const messageBox = new MessageBox({
+  messages: {
+    en: {
+      conditional: '{{# if (value) { }}true{{# } else { }}false{{# } }}',
+    }
+  },
+  evaluate: SUGGESTED_EVALUATE,
+});
+```

--- a/lib/MessageBox.js
+++ b/lib/MessageBox.js
@@ -7,14 +7,20 @@ class MessageBox {
     messages,
     tracker,
     interpolate,
+    evaluate,
+    escape,
   } = {}) {
     this.language = initialLanguage || MessageBox.language || 'en';
     this.messageList = messages || {};
     if (tracker) this.trackerDep = new tracker.Dependency();
 
-    // Default interpolate regex test
-    // https://regex101.com/r/8sRC8b/2
-    this.interpolate = interpolate || MessageBox.interpolate || /{{([^\{\}][\s\S]+?)}}/g;
+    // Default lodash templates regexs
+    // https://regex101.com/r/ce27tA/5
+    this.interpolate = interpolate || MessageBox.interpolate || /{{{([^\{\}#][\s\S]+?)}}}/g;
+    // https://regex101.com/r/ndDqxg/4
+    this.evaluate = evaluate || MessageBox.evaluate || /{{#([^\{\}].*?)}}/g;
+    // https://regex101.com/r/8sRC8b/8
+    this.escape = escape || MessageBox.escape || /{{([^\{\}#][\s\S]+?)}}/g;
   }
 
   messages(messages) {
@@ -66,7 +72,13 @@ class MessageBox {
 
     if (message && typeof message === 'object') message = message[genericName] || message._default; // eslint-disable-line no-underscore-dangle
 
-    if (typeof message === 'string') message = template(message, { interpolate: this.interpolate });
+    if (typeof message === 'string') {
+      message = template(message, {
+        interpolate: this.interpolate,
+        evaluate: this.evaluate,
+        escape: this.escape,
+      });
+    }
 
     if (typeof message !== 'function') return `${fieldName} is invalid`;
 

--- a/lib/MessageBox.js
+++ b/lib/MessageBox.js
@@ -1,14 +1,17 @@
-import Handlebars from 'handlebars';
 import deepExtend from 'deep-extend';
+import template from 'lodash.template';
+// import template from 'lodash.template';
 
 class MessageBox {
   constructor({
     initialLanguage,
     messages,
     tracker,
+    interpolate,
   } = {}) {
     this.language = initialLanguage || MessageBox.language || 'en';
     this.messageList = messages || {};
+    this.interpolate = interpolate || MessageBox.interpolate || /{{([\s\S]+?)}}/g;
     if (tracker) this.trackerDep = new tracker.Dependency();
   }
 
@@ -61,7 +64,7 @@ class MessageBox {
 
     if (message && typeof message === 'object') message = message[genericName] || message._default; // eslint-disable-line no-underscore-dangle
 
-    if (typeof message === 'string') message = Handlebars.compile(message);
+    if (typeof message === 'string') message = template(message, { interpolate: this.interpolate });
 
     if (typeof message !== 'function') return `${fieldName} is invalid`;
 
@@ -83,8 +86,10 @@ class MessageBox {
   static defaults({
     initialLanguage,
     messages,
+    interpolate,
   } = {}) {
     if (typeof initialLanguage === 'string') MessageBox.language = initialLanguage;
+    if (interpolate instanceof RegExp) MessageBox.interpolate = interpolate;
 
     if (messages) {
       if (!MessageBox.messages) MessageBox.messages = {};

--- a/lib/MessageBox.js
+++ b/lib/MessageBox.js
@@ -1,6 +1,5 @@
 import deepExtend from 'deep-extend';
 import template from 'lodash.template';
-// import template from 'lodash.template';
 
 class MessageBox {
   constructor({
@@ -11,8 +10,11 @@ class MessageBox {
   } = {}) {
     this.language = initialLanguage || MessageBox.language || 'en';
     this.messageList = messages || {};
-    this.interpolate = interpolate || MessageBox.interpolate || /{{([\s\S]+?)}}/g;
     if (tracker) this.trackerDep = new tracker.Dependency();
+
+    // Default interpolate regex test
+    // https://regex101.com/r/8sRC8b/2
+    this.interpolate = interpolate || MessageBox.interpolate || /{{([^\{\}][\s\S]+?)}}/g;
   }
 
   messages(messages) {

--- a/lib/MessageBox.js
+++ b/lib/MessageBox.js
@@ -1,6 +1,14 @@
 import deepExtend from 'deep-extend';
 import template from 'lodash.template';
 
+// Default lodash templates regexs
+// https://regex101.com/r/ce27tA/5
+export const DEFAULT_INTERPOLATE = /{{{([^\{\}#][\s\S]+?)}}}/g;
+// https://regex101.com/r/8sRC8b/8
+export const DEFAULT_ESCAPE = /{{([^\{\}#][\s\S]+?)}}/g;
+// https://regex101.com/r/ndDqxg/4
+export const SUGGESTED_EVALUATE = /{{#([^\{\}].*?)}}/g;
+
 class MessageBox {
   constructor({
     initialLanguage,
@@ -14,13 +22,10 @@ class MessageBox {
     this.messageList = messages || {};
     if (tracker) this.trackerDep = new tracker.Dependency();
 
-    // Default lodash templates regexs
-    // https://regex101.com/r/ce27tA/5
-    this.interpolate = interpolate || MessageBox.interpolate || /{{{([^\{\}#][\s\S]+?)}}}/g;
-    // https://regex101.com/r/ndDqxg/4
-    this.evaluate = evaluate || MessageBox.evaluate || /{{#([^\{\}].*?)}}/g;
-    // https://regex101.com/r/8sRC8b/8
-    this.escape = escape || MessageBox.escape || /{{([^\{\}#][\s\S]+?)}}/g;
+    // Template options
+    this.interpolate = interpolate || MessageBox.interpolate || DEFAULT_INTERPOLATE;
+    this.evaluate = evaluate || MessageBox.evaluate;
+    this.escape = escape || MessageBox.escape || DEFAULT_ESCAPE;
   }
 
   messages(messages) {
@@ -101,9 +106,14 @@ class MessageBox {
     initialLanguage,
     messages,
     interpolate,
+    evaluate,
+    escape,
   } = {}) {
     if (typeof initialLanguage === 'string') MessageBox.language = initialLanguage;
+
     if (interpolate instanceof RegExp) MessageBox.interpolate = interpolate;
+    if (evaluate instanceof RegExp) MessageBox.evaluate = evaluate;
+    if (escape instanceof RegExp) MessageBox.escape = escape;
 
     if (messages) {
       if (!MessageBox.messages) MessageBox.messages = {};

--- a/lib/MessageBox.tests.js
+++ b/lib/MessageBox.tests.js
@@ -79,6 +79,7 @@ describe('MessageBox', function () {
       messages: {
         en: {
           required: '{{name}} is required',
+          number: '{{{name}}} is not a number',
         },
       },
     });
@@ -87,6 +88,11 @@ describe('MessageBox', function () {
       name: 'foo',
       type: 'required',
     })).toEqual('foo is required');
+
+    expect(messageBox.message({
+      name: 'bar',
+      type: 'number',
+    })).toEqual('{bar} is not a number');
   });
 
   it('custom interpolate in messages works', function () {

--- a/lib/MessageBox.tests.js
+++ b/lib/MessageBox.tests.js
@@ -1,4 +1,4 @@
-import MessageBox from './MessageBox';
+import MessageBox, { SUGGESTED_EVALUATE} from './MessageBox';
 import expect, { createSpy } from 'expect';
 
 describe('MessageBox', function () {
@@ -120,6 +120,7 @@ describe('MessageBox', function () {
 
   it('template with conditional works', function() {
     const messageBox = new MessageBox({
+      evaluate: SUGGESTED_EVALUATE,
       messages: {
         en: {
           conditional: '{{# if (value) { }}true{{# } else { }}false{{# } }}',

--- a/lib/MessageBox.tests.js
+++ b/lib/MessageBox.tests.js
@@ -92,7 +92,50 @@ describe('MessageBox', function () {
     expect(messageBox.message({
       name: 'bar',
       type: 'number',
-    })).toEqual('{bar} is not a number');
+    })).toEqual('bar is not a number');
+  });
+
+  it('template in messages with html works', function () {
+    const messageBox = new MessageBox({
+      messages: {
+        en: {
+          minNumber: '<strong>{{{name}}}</strong> must be at least {{min}}',
+          maxNumber: '<div id="field">{{name}}</div> cannot exceed {{max}}',
+        },
+      },
+    });
+
+    expect(messageBox.message({
+      name: '<bar>',
+      type: 'minNumber',
+      min: 10,
+    })).toEqual('<strong><bar></strong> must be at least 10');
+
+    expect(messageBox.message({
+      name: '<bar>',
+      type: 'maxNumber',
+      max: 100,
+    })).toEqual('<div id="field">&lt;bar&gt;</div> cannot exceed 100');
+  });
+
+  it('template with conditional works', function() {
+    const messageBox = new MessageBox({
+      messages: {
+        en: {
+          conditional: '{{# if (value) { }}true{{# } else { }}false{{# } }}',
+        },
+      },
+    });
+
+    expect(messageBox.message({
+      value: true,
+      type: 'conditional',
+    })).toEqual('true');
+
+    expect(messageBox.message({
+      value: false,
+      type: 'conditional',
+    })).toEqual('false');
   });
 
   it('custom interpolate in messages works', function () {
@@ -102,6 +145,7 @@ describe('MessageBox', function () {
         en: {
           required: '<%= name %> is required',
           number: '#{name} is not a number',
+          maxNumber: '<div id="field">#{name}</div> cannot exceed <%= max %>',
         },
       },
     });
@@ -115,6 +159,12 @@ describe('MessageBox', function () {
       name: 'bar',
       type: 'number',
     })).toEqual('bar is not a number');
+
+    expect(messageBox.message({
+      name: 'bar',
+      type: 'maxNumber',
+      max: 100,
+    })).toEqual('<div id="field">bar</div> cannot exceed 100');
   });
 
   it('uses the message on error info if provided', function () {

--- a/lib/MessageBox.tests.js
+++ b/lib/MessageBox.tests.js
@@ -74,7 +74,7 @@ describe('MessageBox', function () {
     }, { language: 'es-ES' })).toEqual('Es requerido');
   });
 
-  it('handlebars in messages works', function () {
+  it('template in messages works', function () {
     const messageBox = new MessageBox({
       messages: {
         en: {
@@ -87,6 +87,28 @@ describe('MessageBox', function () {
       name: 'foo',
       type: 'required',
     })).toEqual('foo is required');
+  });
+
+  it('custom interpolate in messages works', function () {
+    const messageBox = new MessageBox({
+      interpolate: /(?:(?:[#|$]{|<%)[=|-]?)([\s\S]+?)(?:}|%>)/g,
+      messages: {
+        en: {
+          required: '<%= name %> is required',
+          number: '#{name} is not a number',
+        },
+      },
+    });
+
+    expect(messageBox.message({
+      name: 'foo',
+      type: 'required',
+    })).toEqual('foo is required');
+
+    expect(messageBox.message({
+      name: 'bar',
+      type: 'number',
+    })).toEqual('bar is not a number');
   });
 
   it('uses the message on error info if provided', function () {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "deep-extend": "^0.4.1",
-    "handlebars": "^4.0.5"
+    "lodash.template": "^4.4.0"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",


### PR DESCRIPTION
This PR is a suggestion to solve #3.

- Keep support for templates;
- Adds support to customize interpolation regex
- Replaces the handlebars for lodash template;

The lodash template is more simple (and smaller) than handlerbars.