### PR TITLE
Replace deep-extend by lodash.defaultsdeep to prevent buffer issue on Meteor 1.5

### DIFF
--- a/lib/MessageBox.js
+++ b/lib/MessageBox.js
@@ -1,5 +1,5 @@
 import Handlebars from 'handlebars';
-import deepExtend from 'deep-extend';
+import defaultsDeep from 'lodash.defaultsdeep';
 
 class MessageBox {
   constructor({
@@ -13,7 +13,7 @@ class MessageBox {
   }
 
   messages(messages) {
-    deepExtend(this.messageList, messages);
+    defaultsDeep(this.messageList, messages);
   }
 
   getMessages(language) {
@@ -26,7 +26,7 @@ class MessageBox {
 
     let messages = this.messageList[language];
     if (messages) {
-      if (globalMessages) messages = deepExtend({}, globalMessages, messages);
+      if (globalMessages) messages = defaultsDeep({}, globalMessages, messages);
     } else {
       messages = globalMessages;
     }
@@ -88,7 +88,7 @@ class MessageBox {
 
     if (messages) {
       if (!MessageBox.messages) MessageBox.messages = {};
-      deepExtend(MessageBox.messages, messages);
+      defaultsDeep(MessageBox.messages, messages);
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "test:watch": "npm test -- --watch"
   },
   "dependencies": {
-    "deep-extend": "^0.4.1",
-    "handlebars": "^4.0.5"
+    "handlebars": "^4.0.5",
+    "lodash.defaultsdeep": "^4.6.0"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",


### PR DESCRIPTION
Fix dependency on node-message-box first in order to fix [node-simple-schema#151](https://github.com/aldeed/node-simple-schema/issues/151)