### PR TITLE
Fix: Transpiling failing in web.browser.legacy Meteor packages

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,12 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "8"
+          "node": "8",
+          "chrome": 16,
+          "edge": 12,
+          "firefox": 11,
+          "ie": 10,
+          "safari": 7
         }
       }
     ]

--- a/.babelrc
+++ b/.babelrc
@@ -1,17 +1,7 @@
 {
   "presets": [
     [
-      "@babel/preset-env",
-      {
-        "targets": {
-          "node": "8",
-          "chrome": 16,
-          "edge": 12,
-          "firefox": 11,
-          "ie": 10,
-          "safari": 7
-        }
-      }
+      "@babel/preset-env"
     ]
   ],
   "plugins": [


### PR DESCRIPTION
Greetings @aldeed 

I'm updated the `.babelrc` file with config based on the passed object to `setMinimumBrowserVersions()` in Meteor package `socket-stream-client`:

https://github.com/meteor/meteor/blob/release/METEOR%401.10.2/packages/socket-stream-client/server.js

It's pseudo-official Meteor's minimum legacy version for each browser:

```
          "chrome": 16,
          "edge": 12,
          "firefox": 11,
          "ie": 10,
          "safari": 7
```

Fixes: https://github.com/aldeed/js-message-box/issues/16
Fixes: https://github.com/meteor/meteor/issues/11033

Best wishes,
Sergey.